### PR TITLE
postsデータ作成時のDBアクセスの削減

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,27 @@
 
 
 ## initial score
-* Language: Ruby
-  (失敗)
+(失敗)
+
+言語：Ruby
 ```
 {"pass":false,"score":0,"success":9,"fail":8,"messages":["response code should be 403, got 200 (GET /login)","ステータスコードが正しくありません: expected 422, got 200 (GET /login)","ユーザー名が表示されていません (GET /)","リダsts/9391$', got '/login' (GET /login)","リダイレクト先URLが正しくありません: expected '^/posts/\\d+$', got '/login' (GET /login)","ログインエラーメッセージが表示されていません (GET /login)"]}
 ```
 
-* Language: PHP
-修正後(成功)
+
+### docker compose修正後
+See: https://github.com/catatsuy/private-isu/pull/425
+
+言語：PHP(以降同じ)
 ```
 {"pass":true,"score":0,"success":121,"fail":64,"messages":["リクエストがタイムアウトしました (GET /)","リクエストがタイムアウトしました (GET /image/10000.png)","リクエストがタイムアウトしました (GET /image/10012.jpg)","リクエスた (GET /image/4764.jpg)","リクエストがタイムアウトしました (GET /image/6239.jpg)","リクエストがタイムアウトしました (GET /image/7962.jpg)","リクエストがタイムアウトしました (GET /image/8510.gif)","リクエストがタイムアウトしまし","リクエストがタイムアウトしました (GET /image/9057.jpg)","リクエストがタイムアウトしました (GET /image/9216.gif)","リクエストがタイムアウトしました (GET /image/9359.jpg)","リクエストがタイムアウトしました (GET /image/9996.jpgストがタイムアウトしました (GET /image/9997.jpg)","リクエストがタイムアウトしました (GET /image/9998.jpg)","リクエストがタイムアウトしました (GET /image/9999.jpg)","リクエストがタイムアウトしました (POST /login)","リクエストがタイムアウトしました (POST /register)"]}
+```
+
+## fix and score
+### DBアクセスの改善：postsデータの作成
+See: https://github.com/23akei/practice-private-isu/pull/2
+
+変更後のベンチマーク結果
+```
+{"pass":true,"score":1614,"success":1502,"fail":1,"messages":["ステータスコードが正しくありません: expected 200, got 404 (GET /posts/10022)"]}
 ```


### PR DESCRIPTION
## 変更前後のスコア推移
before: 0
after: 1614

## 変更経緯
docker composeで立ち上げたアプリケーションのトップページにブラウザからアクセスした。
ブラウザの開発者ツールのウォーターフォール図を見てトップページの読み込みに800ms前後かかっていることが判明。

また、ベンチマークを結果のmesseageに以下のようなものが含まれ、トップページの読み込みが遅いことがわかった。
```
"リクエストがタイムアウトしました (GET /)"
```

そこで、トップページ( `/` )の高速化を方針としてコードを追った。(現時点では時間計測やパフォーマンステスト等は行っていない）

その過程で、トップページ等で利用されるmake_posts関数において二重のforeach文中でDBにクエリを投げている箇所を発見した。
https://github.com/23akei/practice-private-isu/blob/f291f7fad0967078a2739c35385f1865013b3cc5/php/index.php#L128

だいたい 「取得するポスト数\*コメント数: デフォルトだと20\*3=60」のクエリが投げられていた。

これを改善することを目的とした。

## 変更内容
* `make_posts()`の最初にusersテーブルとcommentsテーブルの全体を取得して以後PHPの変数としてテーブルを扱うように変更。
  - make_posts()内ではデータの更新等は無く、取得したデータを組み立てるだけなので問題ない

## 変更後
変更後、ブラウザからのトップページへのアクセスが600ms程度まで改善された。
また、ベンチマークスコアも1614まで向上した。

まだ改善の余地があるため、詳細な調査が必要であると考える。

## 変更しなかった内容・TODO
* get("/")内でのposts全件取得: POSTS_PER_PAGE=20だけ取得すればよい気がしたが、パフォーマンスにはそんなに影響しないと判断。
  - しかしこれではトップページへのアクセスの度に全テーブルの全データを取得しているので、メモリの最適化をする必要がある気が…
  - メモリ・時間両面からの計測が必要
* コメントとユーザの全件取得の必要あったか…？